### PR TITLE
[fix] Fixed toggle status and refactor task and utils modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ The goals of this plugin are:
 
 ![AfterQuery](https://github.com/huantrinh1802/m_taskwarrior_d.nvim/blob/main/demo/screenshots/AfterQueryView.png)
 
-
 ## Features
 
 - [x] Injected and concealed TaskWarrior task
@@ -73,7 +72,6 @@ The goals of this plugin are:
 
 - [TaksWarrior](https://taskwarrior.org/) (pre3.0) (hard required)
   - Have not tested v3.0 but it may have a breaking change due to its move to SQLite as the main storage engine
-- [jq](https://jqlang.github.io/jq/) (required)
 - [nui.nvim](https://github.com/MunifTanjim/nui.nvim)
   - For all UIs in the plugin
 
@@ -99,6 +97,7 @@ The goals of this plugin are:
 ```lua
 {
     "huantrinh1802/m_taskwarrior_d.nvim/",
+    version = "*",
     dependencies = { "MunifTanjim/nui.nvim" },
     config = function()
     -- Require
@@ -176,7 +175,7 @@ If you are using `obsidian.nvim`, you can use the following configuration:
 ### Commands
 
 - `:TWToggle`: toggle status of task
-  - It also checks the parent task (if any) to determine the final status and apply it. The logic is as follows:
+  - If the task is registered in TaskWarrior, it also checks the parent task (if any) to determine the final status and apply it. The logic is as follows:
     - If there are any started tasks, it returns `started`.
     - If there are pending tasks but no started tasks, it returns `pending`.
     - If there are completed tasks, it returns `completed`.
@@ -200,12 +199,12 @@ If you are using `obsidian.nvim`, you can use the following configuration:
   - It will be dismissed once the cursor moves or reenter the buffer
 - `:TWRunWithCurrent`: extract the current UUID, and ask user for input. Run the command as follow `!task {uuid} {user input}`
 - `:TWRun`: there are two ways to use this command:
-  1. `TWRun` without any arguments, an input component will appear and ask for your command
+  - `TWRun` without any arguments, an input component will appear and ask for your command
     - Enter empty again, it will run `task`
-  2. `TWRun {command}`
-  - Run the command as follow `task {user input}`
-    - If the command has `add`, `del`, `mod` or `purge`, the output will print out only
-    - Otherwise, the output will be put into a float, focusable window under the cursor. It is dismissed once the cursor moves or reenter the buffer
+  - `TWRun {command}`
+    - Run the command as follow `task {user input}`
+      - If the command has `add`, `del`, `mod` or `purge`, the output will print out only
+      - Otherwise, the output will be put into a float, focusable window under the cursor. It is dismissed once the cursor moves or reenter the buffer
 - `:TWFocusFloat`: switch the focus to a floating window (or hover, triggered by `TWView`, `TWRunWithCurrent`, and `TWRun`).
 - `:TWEditSavedQueries`: display a buffer with list of saved queries. Each query should be a valid TaskWarrior query that can be run with `task {query}`
   - Each query can be edited and saved as you could with any buffer
@@ -233,7 +232,7 @@ If you are using `obsidian.nvim`, you can use the following configuration:
 ### QueryView
 
 ```markdown
-# Tasks that are in pending of project A $query{+PENDING project:A}
+# Tasks that are in pending of project A $query{status:pending project:A}
 ```
 
 ## License

--- a/lua/m_taskwarrior_d/task.lua
+++ b/lua/m_taskwarrior_d/task.lua
@@ -46,10 +46,10 @@ function M.get_task_by(task_id, return_data)
 end
 -- Function to add a task
 function M.add_task(description)
-  description = require('m_taskwarrior_d.utils').trim(description)
+  description = require("m_taskwarrior_d.utils").trim(description)
   local command = string.format("task rc.verbose=new-uuid add '%s'", description)
   local _, result = M.execute_taskwarrior_command(command, true)
-  local task_uuid = string.match(result, '%x*-%x*-%x*-%x*-%x*')
+  local task_uuid = string.match(result, "%x*-%x*-%x*-%x*-%x*")
   return task_uuid
 end
 
@@ -91,7 +91,7 @@ function M.add_task_deps(current_task_id, deps)
 end
 
 function M.get_blocked_tasks_by(uuid)
-  local command = string.format("task depends:%s", uuid)
+  local command = string.format("task depends:%s export", uuid)
   local status, result = M.execute_taskwarrior_command(command, true)
   return status, result
 end
@@ -101,7 +101,15 @@ function M.get_tasks_by(uuids)
   for _, uuid in ipairs(uuids) do
     local _, result = M.execute_taskwarrior_command(string.format("task %s export", uuid), true)
     if result then
-      table.insert(tasks, result[1])
+      if vim == nil then
+        local json = require("cjson")
+        result = json.decode(result)
+      else
+        result = vim.fn.json_decode(result)
+      end
+      if result then
+        table.insert(tasks, result[1])
+      end
     end
   end
   return true, tasks

--- a/lua/m_taskwarrior_d/utils.lua
+++ b/lua/m_taskwarrior_d/utils.lua
@@ -175,14 +175,7 @@ function M.update_related_tasks_statuses(uuid)
     tasks = vim.fn.json_decode(result)
   end
   for _, task in ipairs(tasks) do
-    local _, dependencies_result = task_mod.get_tasks_by(concat_with_quotes(task["depends"]))
-    local dependencies
-    if vim == nil then
-      local json = require("cjson")
-      dependencies = json.decode(dependencies_result)
-    else
-      dependencies = vim.fn.json_decode(dependencies_result)
-    end
+    local _, dependencies = task_mod.get_tasks_by(task["depends"])
     local new_status = calculate_final_status(dependencies)
     local line_number = find_pattern_line(task.uuid)
     new_status, _ = findPair(M.status_map, nil, new_status)


### PR DESCRIPTION
- Use double quotes for strings in task.lua
- Add "export" option to "task depends" command in get_blocked_tasks_by function
- Simplify result processing in get_tasks_by function by extracting json decoding to external function
- Remove redundant json decoding in update_related_tasks_statuses function in utils.lua
- Simplify dependencies assignment in for-loop of update_related_tasks_statuses function