### PR TITLE
[fix+modify] Update task dependencies command and improve task status calculation logic

### DIFF
--- a/lua/m_taskwarrior_d/task.lua
+++ b/lua/m_taskwarrior_d/task.lua
@@ -91,7 +91,7 @@ function M.add_task_deps(current_task_id, deps)
 end
 
 function M.get_blocked_tasks_by(uuid)
-  local command = string.format("task depends:%s export", uuid)
+  local command = string.format("task depends.has:%s export", uuid)
   local status, result = M.execute_taskwarrior_command(command, true)
   return status, result
 end

--- a/lua/m_taskwarrior_d/utils.lua
+++ b/lua/m_taskwarrior_d/utils.lua
@@ -131,17 +131,16 @@ local function calculate_final_status(tasks)
       deletedCount = deletedCount + 1
     end
   end
-  if startedCount > 0 then
-    return "started"
-  elseif pendingCount > 0 then
+  if pendingCount == #tasks then
     return "pending"
-  elseif completedCount > 0 then
-    return "completed"
-  elseif deletedCount > 0 then
-    return "deleted"
-  else
-    return "unknown" -- or any other default value
   end
+  if completedCount == #tasks or (completedCount > 0 and (completedCount + deletedCount) == #tasks) then
+    return "completed"
+  end
+  if deletedCount == #tasks then
+    return "deleted"
+  end
+  return "started"
 end
 
 local function find_pattern_line(pattern)


### PR DESCRIPTION
- Changed task dependencies command from "task depends:%s export" to "task depends .has:%s export"
- Revised the final status calculation in tasks to more accurately reflect status based on task occurrences.