### PR TITLE
Fix installation code in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The goals of this plugin are:
 
 ```lua
 {
-    "huantrinh1802/m_taskwarrior_d.nvim/",
+    "huantrinh1802/m_taskwarrior_d.nvim",
     version = "*",
     dependencies = { "MunifTanjim/nui.nvim" },
     config = function()


### PR DESCRIPTION
Corrected the installation code in README.md.

## WHY

When I used the Installation code as is, lazy.nvim caused an installation error.

## CHANGE

```diff
{
- "huantrinh1802/m_taskwarrior_d.nvim/"
+ "huantrinh1802/m_taskwarrior_d.nvim"
    -- ...
}
```

It appears that lazy.nvim is sensitive to trailing slashes.