### PR TITLE
fix: update query task and its deletion logic

### DIFF
--- a/lua/m_taskwarrior_d/init.lua
+++ b/lua/m_taskwarrior_d/init.lua
@@ -13,6 +13,7 @@ M._config = {
   task_whitelist_path = { },
   view_task_config = { total_width = 62, head_width = 15 },
   fields_order = { "project", "description", "urgency", "status", "tags", "annotations" }
+
 }
 
 function M.sync_tasks(start_position, end_position)
@@ -564,6 +565,7 @@ function M.query_tasks()
     end
   end
   local markdown = M.utils.render_tasks(final)
+  table.insert(markdown, "")
   local no_of_lines = vim.api.nvim_buf_line_count(0)
   if no_of_lines == line_number then
     vim.api.nvim_buf_set_lines(0, no_of_lines, no_of_lines, false, { "" })

--- a/lua/m_taskwarrior_d/utils.lua
+++ b/lua/m_taskwarrior_d/utils.lua
@@ -420,14 +420,15 @@ function M.delete_scoped_tasks(line_number)
   while end_line == nil and next_line_number <= no_of_lines do
     count = count + 1
     next_line, next_line_number = M.get_line(line_number+count)
-    if next_line == ' ' or next_line_number == no_of_lines then
+    local list_sb, _, status = string.match(next_line, M.checkbox_pattern.lua)
+    if #next_line == 0 or next_line == ' ' or next_line_number == no_of_lines or list_sb == nil then
       end_line = next_line_number
     end
   end
   if end_line == nil then
     end_line = no_of_lines
   end
-  vim.api.nvim_buf_set_lines(0, start_line - 1, end_line, false, {})
+  vim.api.nvim_buf_set_lines(0, start_line, end_line, false, {})
 end
 
 return M


### PR DESCRIPTION
- Ensure an extra empty string is inserted into the `markdown` variable within `M.query_tasks()`.
- Modify the condition in `M.delete_scoped_tasks` to account for lines equal to `nil` or those that do not match `M.checkbox_pattern.lua`.
- Change the starting line for deletion operation from `start_line - 1` to `start_line` to correctly scope deletion of tasks.

close #39 