### PR TITLE
feat: Add configurable closing keymap

### DIFF
--- a/lua/m_taskwarrior_d/init.lua
+++ b/lua/m_taskwarrior_d/init.lua
@@ -14,6 +14,7 @@ M._config = {
   view_task_config = { total_width = 62, head_width = 15 },
   fields_order = { "project", "description", "urgency", "status", "tags", "annotations" }
 
+  floating_buffer_exit_keys = { "q", "<Esc>", "<C-c>" }
 }
 
 function M.sync_tasks(start_position, end_position)
@@ -512,7 +513,7 @@ function M.toggle_saved_queries(type)
       keymap = {
         focus_next = { "j", "<Down>", "<Tab>" },
         focus_prev = { "k", "<Up>", "<S-Tab>" },
-        close = { "q", "<Esc>", "<C-c>" },
+        close = M._config.floating_buffer_exit_keys,
         submit = { "<CR>", "<Space>" },
       },
       on_submit = function(item)

--- a/lua/m_taskwarrior_d/ui.lua
+++ b/lua/m_taskwarrior_d/ui.lua
@@ -1,8 +1,14 @@
-local M = {}
+local M = { _config = {} }
+
+function M.set_config(opts)
+  for k, v in pairs(opts) do
+    M._config[k] = v
+  end
+end
 
 function M.trigger_hover(contents, title)
   if title == nil then
-    title = ''
+    title = ""
   end
   local Popup = require("nui.popup")
   local event = require("nui.utils.autocmd").event
@@ -12,14 +18,14 @@ function M.trigger_hover(contents, title)
     max_width = math.max(max_width, #content)
   end
   local popup = Popup({
-    enter = false,
+    enter = true,
     focusable = true,
     border = {
       style = "rounded",
       text = {
         top = title,
         top_align = "center",
-      }
+      },
     },
     relative = "cursor",
     position = 0,
@@ -31,13 +37,15 @@ function M.trigger_hover(contents, title)
 
   -- mount/open the component
   local bufnr = vim.api.nvim_get_current_buf()
-  autocmd.buf.define(bufnr, { event.CursorMoved, event.BufWinLeave }, function()
+  autocmd.buf.define(bufnr, { event.BufWinLeave }, function()
     popup:unmount()
   end, { once = true })
   popup:mount()
 
   vim.api.nvim_buf_set_lines(popup.bufnr, 0, 1, false, contents)
-    vim.api.nvim_buf_set_keymap(popup.bufnr, "n", "q", "<Cmd>q<CR>", { silent = true })
+  for _, key in ipairs(M._config.close_floating_buffer) do
+    vim.api.nvim_buf_set_keymap(popup.bufnr, "n", key, "<Cmd>q<CR>", { silent = true })
+  end
   return popup
 end
 


### PR DESCRIPTION
- Added `floating_buffer_exit_keys` in `config` which contains keys to close floating buffer.
- Modified `close` attribute in `toggle_saved_queries` function to use keys from `config.floating_buffer_exit_keys`.
- Implemented `set_config` function in `ui.lua` to update the configuration options.
- Changed attribute `enter` in `trigger_hover` function from `false` to `true`.
- Restructured `trigger_hover` function to use keys from `config.close_floating_buffer` for closing the buffer.

close #36 