### PR TITLE
fix: Rename floating buffer key configurations

### DIFF
--- a/lua/m_taskwarrior_d/init.lua
+++ b/lua/m_taskwarrior_d/init.lua
@@ -13,7 +13,7 @@ M._config = {
   task_whitelist_path = {},
   view_task_config = { total_width = 62, head_width = 15 },
   fields_order = { "project", "description", "urgency", "status", "tags", "annotations" },
-  floating_buffer_exit_keys = { "q", "<Esc>", "<C-c>" },
+  close_floating_buffer = { "q", "<Esc>", "<C-c>" },
 }
 
 function M.sync_tasks(start_position, end_position)
@@ -512,7 +512,7 @@ function M.toggle_saved_queries(type)
       keymap = {
         focus_next = { "j", "<Down>", "<Tab>" },
         focus_prev = { "k", "<Up>", "<S-Tab>" },
-        close = M._config.floating_buffer_exit_keys,
+        close = M._config.close_floating_buffer,
         submit = { "<CR>", "<Space>" },
       },
       on_submit = function(item)


### PR DESCRIPTION
- Renamed 'floating_buffer_exit_keys' to 'close_floating_buffer'
- Updated references to 'floating_buffer_exit_keys' with the new name 'close_floating_buffer' in toggle_saved_queries function