### PR TITLE
feat: Upgrade TWUpdateCurrent task update functionality in Taskwarrior

### DIFF
--- a/lua/m_taskwarrior_d/init.lua
+++ b/lua/m_taskwarrior_d/init.lua
@@ -96,9 +96,13 @@ function M.toggle_task()
 end
 
 function M.update_current_task()
-  local current_line, line_number = M.utils.get_line()
-  local result, _ = M.utils.add_or_sync_task(current_line, true)
-  vim.api.nvim_buf_set_lines(0, line_number - 1, line_number, false, { result })
+  local start_line = vim.fn.line("'<") -- Get the start line of the selection
+  local end_line = vim.fn.line("'>") -- Get the end line of the selection
+  for line_num = start_line, end_line do
+    local current_line, line_number = M.utils.get_line(line_num)
+    local result, _ = M.utils.add_or_sync_task(current_line, true)
+    vim.api.nvim_buf_set_lines(0, line_number - 1, line_number, false, { result })
+  end
 end
 
 local function find_next_index(item, inserted_list, table)
@@ -655,7 +659,7 @@ function M.setup(opts)
   end, { range = true })
   vim.api.nvim_create_user_command("TWUpdateCurrent", function()
     M.update_current_task()
-  end, {})
+  end, { range = true })
   vim.api.nvim_create_user_command("TWEditTask", function()
     M.edit_task()
   end, {})


### PR DESCRIPTION
- Changed update_current_task method in m_taskwarrior_d/init.lua to handle range of lines
- Added a range to the TWUpdateCurrent command to manage multiple update at once
- Updated the method to loop over selected lines and perform update
- This enables updating multiple tasks at once instead of a single task at a time