### PR TITLE
feat: replace 'started' status with 'active' in task management

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ The goals of this plugin are:
   -- The order of toggling task statuses
   task_statuses = { " ", ">", "x", "~" },
   -- The mapping between status and symbol in checkbox
-  status_map = { [" "] = "pending", [">"] = "started", ["x"] = "completed", ["~"] = "deleted" },
+  status_map = { [" "] = "pending", [">"] = "active", ["x"] = "completed", ["~"] = "deleted" },
   -- More configurations will be added in the future
 }
 ```
@@ -142,7 +142,7 @@ The goals of this plugin are:
 ### Statuses
 
 - `pending`: corresponding to `pending` status
-- `started`: corresponding to `pending` status and `stated` tag
+- `active`: has `active` attribute 
 - `completed`: corresponding to `completed` status
 - `deleted`: corresponding to `deleted` status
 
@@ -176,7 +176,7 @@ If you are using `obsidian.nvim`, you can use the following configuration:
 
 - `:TWToggle`: toggle status of task
   - If the task is registered in Taskwarrior, it also checks the parent task (if any) to determine the final status and apply it. The logic is as follows:
-    - If there are any started tasks, it returns `started`.
+    - If there are any started tasks, it returns `active`.
     - If there are pending tasks but no started tasks, it returns `pending`.
     - If there are completed tasks, it returns `completed`.
     - If they are all deleted tasks, it returns `deleted`.

--- a/lua/m_taskwarrior_d/init.lua
+++ b/lua/m_taskwarrior_d/init.lua
@@ -7,7 +7,7 @@ M._concealTaskId = nil
 M.current_winid = nil
 M._config = {
   task_statuses = { " ", ">", "x", "~" },
-  status_map = { [" "] = "pending", [">"] = "started", ["x"] = "completed", ["~"] = "deleted" },
+  status_map = { [" "] = "pending", [">"] = "active", ["x"] = "completed", ["~"] = "deleted" },
   id_pattern = { vim = "\\x*-\\x*-\\x*-\\x*-\\x*", lua = "%x*-%x*-%x*-%x*-%x*" },
   list_pattern = { lua = "[%-%*%+]", vim = "[\\-\\*\\+]" },
   task_whitelist_path = {},

--- a/lua/m_taskwarrior_d/task.lua
+++ b/lua/m_taskwarrior_d/task.lua
@@ -76,11 +76,11 @@ end
 --Function to modify task's status completed, (pending), deleted, started, canceled
 function M.modify_task_status(task_id, new_status)
   local command
-  if M.status_map[new_status] == "started" then
-    command = string.format("task %s modify +started status:pending", task_id)
+  if M.status_map[new_status] == "active" then
+    command = string.format("task %s start", task_id)
   else
     local status = M.status_map[new_status]
-    command = string.format("task %s modify status:%s -started", task_id, status)
+    command = string.format("task %s modify status:%s", task_id, status)
   end
   local status, result = M.execute_taskwarrior_command(command)
 end


### PR DESCRIPTION
- Modified the 'status_map' to switch 'started' status to 'active'
- Updated 'modify_task_status' function to handle 'active' status
- Calculated 'active' task count in 'calculate_final_status' function
- Updated 'add_or_sync_task' and 'render_tasks' function to handle 'active' status+