### PR TITLE
Make it possible to configure the checkbox prefix and suffix

### DIFF
--- a/lua/m_taskwarrior_d/init.lua
+++ b/lua/m_taskwarrior_d/init.lua
@@ -10,6 +10,8 @@ M._config = {
   status_map = { [" "] = "pending", [">"] = "active", ["x"] = "completed", ["~"] = "deleted" },
   id_pattern = { vim = "\\x*-\\x*-\\x*-\\x*-\\x*", lua = "%x*-%x*-%x*-%x*-%x*" },
   list_pattern = { lua = "[%-%*%+]", vim = "[\\-\\*\\+]" },
+  checkbox_prefix = "[",
+  checkbox_suffix = "]",
   task_whitelist_path = {},
   view_task_config = { total_width = 62, head_width = 15 },
   task_view_fields_order = { "project", "description", "urgency", "status", "tags", "annotations" },
@@ -589,8 +591,8 @@ local function process_opts(opts)
   end
   local status_pattern = M.utils.encode_patterns(table.concat(M._config.task_statuses, ""))
   M._config["status_pattern"] = {
-    lua = "(%[([" .. status_pattern.lua .. "])%])",
-    vim = "(\\[([" .. status_pattern.vim .. "])\\])",
+    lua = "(%" .. M._config.checkbox_prefix .. "([" .. status_pattern.lua .. "])%" .. M._config.checkbox_suffix ..")",
+    vim = "(\\" .. M._config.checkbox_prefix .."([" .. status_pattern.vim .. "])\\" .. M._config.checkbox_suffix ..")",
   }
   M._config["checkbox_pattern"] = {
     lua = "(" .. M._config.list_pattern.lua .. ") " .. M._config["status_pattern"].lua,

--- a/lua/m_taskwarrior_d/utils.lua
+++ b/lua/m_taskwarrior_d/utils.lua
@@ -1,5 +1,8 @@
 local M = {}
-M.checkbox_pattern = { lua = "([%-%*%+]) (%[([%sx~%>])%])", vim = "([\\-\\*\\+]) (\\[([\\sx~>])\\])" }
+M.checkbox_pattern = {
+  lua = "([%-%*%+]) (%[([%sx~%>])%])",
+  vim = "([\\-\\*\\+]) (\\[([\\sx~>])\\])",
+}
 M.id_pattern = { vim = "(\\$id{([0-9a-fA-F\\-]\\+)})", lua = "(%$id@([0-9a-fA-F$-]+)@)" }
 M.task_pattern = {
   lua = M.checkbox_pattern.lua .. " (.*) " .. M.id_pattern.lua,
@@ -200,7 +203,7 @@ function M.toggle_task_status(current_line, line_number, new_status)
       new_status = M.task_statuses[status_index + 1]
     end
   end
-  local modified_line = string.gsub(current_line, M.status_pattern.lua, "[" .. new_status .. "]")
+  local modified_line = string.gsub(current_line, M.status_pattern.lua, M.checkbox_prefix .. new_status .. M.checkbox_suffix)
   -- Set the modified line back to the buffer
 
   vim.api.nvim_buf_set_lines(0, line_number - 1, line_number, false, { modified_line })
@@ -241,9 +244,9 @@ function M.add_or_sync_task(line, replace_desc)
           require("m_taskwarrior_d.task").modify_task(uuid, desc)
           result = string.rep(" ", spaces or 0)
             .. list_sb
-            .. " ["
+            .. " " .. M.checkbox_prefix
             .. new_task_status_sym
-            .. "] "
+            .. M.checkbox_suffix .. " "
             .. M.trim(desc)
             .. " $id{"
             .. new_task.uuid
@@ -251,9 +254,9 @@ function M.add_or_sync_task(line, replace_desc)
         else
           result = string.rep(" ", spaces or 0)
             .. list_sb
-            .. " ["
+            .. " " .. M.checkbox_prefix
             .. new_task_status_sym
-            .. "] "
+            .. M.checkbox_suffix .. " "
             .. new_task.description
             .. " $id{"
             .. new_task.uuid
@@ -366,9 +369,9 @@ function M.render_tasks(tasks, depth)
     table.insert(
       markdown,
       string.rep(" ", vim.opt_local.shiftwidth._value * depth)
-        .. "- ["
+        .. "- " .. M.checkbox_prefix
         .. new_task_status_sym
-        .. "] "
+        .. M.checkbox_suffix .. " "
         .. task.desc
         .. " $id{"
         .. task.uuid


### PR DESCRIPTION
This PR makes it possible to configure the checkbox prefix and suffix.

Example:
``` lua
require("m_taskwarrior_d").setup({
    checkbox_prefix = "(",
    checkbox_suffix = ")",
})
```