### PR TITLE
[feat] add default list symbol configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,11 @@ The goals of this plugin are:
   task_statuses = { " ", ">", "x", "~" },
   -- The mapping between status and symbol in checkbox
   status_map = { [" "] = "pending", [">"] = "active", ["x"] = "completed", ["~"] = "deleted" },
+  -- The checkbox prefix and suffix
+  checkbox_prefix = "[",
+  checkbox_suffix = "]",
+  -- The default list symbol
+  default_list_symbol = "-",
   -- More configurations will be added in the future
 }
 ```

--- a/lua/m_taskwarrior_d/init.lua
+++ b/lua/m_taskwarrior_d/init.lua
@@ -12,6 +12,7 @@ M._config = {
   list_pattern = { lua = "[%-%*%+]", vim = "[\\-\\*\\+]" },
   checkbox_prefix = "[",
   checkbox_suffix = "]",
+  default_list_symbol = "-",
   task_whitelist_path = {},
   view_task_config = { total_width = 62, head_width = 15 },
   task_view_fields_order = { "project", "description", "urgency", "status", "tags", "annotations" },

--- a/lua/m_taskwarrior_d/utils.lua
+++ b/lua/m_taskwarrior_d/utils.lua
@@ -369,7 +369,9 @@ function M.render_tasks(tasks, depth)
     table.insert(
       markdown,
       string.rep(" ", vim.opt_local.shiftwidth._value * depth)
-        .. "- " .. M.checkbox_prefix
+        .. M.default_list_symbol
+        .. " "
+        .. M.checkbox_prefix
         .. new_task_status_sym
         .. M.checkbox_suffix .. " "
         .. task.desc


### PR DESCRIPTION
- README.md:
  - Added checkbox prefix and suffix configuration.
  - Introduced `default_list_symbol` for list items.

- lua/m_taskwarrior_d/init.lua:
  - Added `default_list_symbol` configuration to the module's config.

- lua/m_taskwarrior_d/utils.lua:
  - Updated render_tasks function to use `default_list_symbol` for list items.