### PR TITLE
fix(init.lua): correct comment suffix encoding for Lua patterns

### DIFF
--- a/lua/m_taskwarrior_d/init.lua
+++ b/lua/m_taskwarrior_d/init.lua
@@ -620,7 +620,7 @@ local function process_opts(opts)
   }
   M._config["task_query_pattern"] = {
     vim = "("..(M._config.comment_prefix and comment_prefix_encoded.vim .. " " or "").."(\\$query{([^\\|]*)|*([^}]*)})"..(M._config.comment_suffix ~= "" and " "..comment_suffix_encoded.vim or "")..")",
-    lua = "("..(M._config.comment_prefix and comment_prefix_encoded.lua .. " " or "").."(%$query{([^%|]*)|*([^}]*)})"..(M._config.comment_suffix ~= "" and " "..comment_suffix_encoded.vim or "")..")",
+    lua = "("..(M._config.comment_prefix and comment_prefix_encoded.lua .. " " or "").."(%$query{([^%|]*)|*([^}]*)})"..(M._config.comment_suffix ~= "" and " "..comment_suffix_encoded.lua or "")..")",
   }
 end
 


### PR DESCRIPTION
Updated the `M._config["task_query_pattern"].lua` to correctly apply the `comment_suffix_encoded.lua` instead of `comment_suffix_encoded.vim`, ensuring proper handling of comment suffixes in Lua patterns.