### PR TITLE
fix: Correct pattern matching in extract_uuid functiond

### DIFF
--- a/lua/m_taskwarrior_d/utils.lua
+++ b/lua/m_taskwarrior_d/utils.lua
@@ -295,7 +295,7 @@ function M.extract_uuid(line)
     return nil
   end
   local uuid_pattern = M.id_part_pattern.lua
-  local conceal, uuid = string.match(line, uuid_pattern)
+  local _, conceal, uuid = string.match(line, uuid_pattern)
   return conceal, uuid
 end
 


### PR DESCRIPTION
- Added missing capture group in string.match call in extract_uuid function

close #74 