### PR TITLE
Added new configuration for the file pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ The goals of this plugin are:
   -- - comment_suffix = "-->",
   comment_prefix = "",
   comment_suffix = "",
+  -- The file pattern to trigger the conceal
+  file_patterns = { "*.md", "*.markdown" },
   -- More configurations will be added in the future
 }
 ```

--- a/lua/m_taskwarrior_d/init.lua
+++ b/lua/m_taskwarrior_d/init.lua
@@ -19,6 +19,7 @@ M._config = {
   close_floating_window = { "q", "<Esc>", "<C-c>" },
   comment_prefix = "",
   comment_suffix = "",
+  file_patterns = { "*.md", "*.markdown" },
 }
 
 function M.sync_tasks(start_position, end_position)
@@ -677,7 +678,7 @@ function M.setup(opts)
   local conceal_group = vim.api.nvim_create_augroup("TWConceal", { clear = true })
   vim.api.nvim_create_autocmd({ "BufEnter" }, {
     group = conceal_group,
-    pattern = "*.md", -- Pattern to match Markdown files
+    pattern = M._config.file_pattern,
     callback = function()
       -- Get the file type of the current buffer
       vim.opt.conceallevel = 2

--- a/lua/m_taskwarrior_d/init.lua
+++ b/lua/m_taskwarrior_d/init.lua
@@ -686,9 +686,9 @@ function M.setup(opts)
         vim.fn.matchadd("Conceal", M._config.id_part_pattern.vim:gsub("[(%(%)]", ""), 0, -1, { conceal = "" })
       M._concealTaskQuery =
         vim.fn.matchadd("Conceal", M._config.task_query_pattern.vim:gsub("[(%(%)]", ""), 0, -1, { conceal = "󰡦" })
-      vim.api.nvim_exec([[hi Conceal ctermfg=109 guifg=#83a598 ctermbg=NONE guibg=NONE]], false)
-      vim.api.nvim_exec([[hi DueDate ctermfg=109 guifg=#6495ED ctermbg=NONE guibg=NONE]], false)
-      vim.api.nvim_exec([[hi DueSoon ctermfg=109 guifg=#FF0000 ctermbg=NONE guibg=NONE]], false)
+      vim.cmd([[hi Conceal ctermfg=109 guifg=#83a598 ctermbg=NONE guibg=NONE]])
+      vim.cmd([[hi DueDate ctermfg=109 guifg=#6495ED ctermbg=NONE guibg=NONE]])
+      vim.cmd([[hi DueSoon ctermfg=109 guifg=#FF0000 ctermbg=NONE guibg=NONE]])
       M.utils.render_virtual_due_dates()
     end,
   })

--- a/lua/m_taskwarrior_d/init.lua
+++ b/lua/m_taskwarrior_d/init.lua
@@ -693,6 +693,18 @@ function M.setup(opts)
     end,
   })
 
+  vim.api.nvim_create_autocmd({ "BufLeave" }, {
+    group = conceal_group,
+    pattern = M._config.file_pattern,
+    callback = function()
+      -- Get the file type of the current buffer
+      vim.opt.conceallevel = 2
+      vim.cmd([[hi Conceal ctermfg=NONE guifg=NONE]])
+      vim.cmd([[hi DueDate ctermfg=NONE guifg=NONE]])
+      vim.cmd([[hi DueSoon ctermfg=NONE guifg=NONE]])
+    end,
+  })
+
   vim.api.nvim_create_user_command("TWToggle", function()
     M.toggle_task()
   end, {})


### PR DESCRIPTION
I added this new configuration because in my editor every time I wanted to open a Markdown file, which may or may not have something to do with task warrior, it took a long time to enter the buffer. I also added an event to delete what is loaded in the `TWConceal` group when it exits the buffer.

Furthermore, I also changed it to not use `nvim_exec` because it is deprecated.
