### PR TITLE
Feature/parse task text

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,39 @@ The goals of this plugin are:
 - [x] Edit task detail within Neovim (through nui.nvim)
 - [x] `Query View` similar to `dateview` in Obsidian or `Viewport` in Taskwiki
 - [x] Virtual text for due and scheduled tasks
+- [x] Inline Taskwarrior attribute parsing
+
+## Inline Taskwarrior Attributes
+
+You can include Taskwarrior attributes directly in your markdown task text. The plugin will parse and apply them to the task in Taskwarrior, then display only the clean description in your markdown.
+
+**Supported attributes:**
+- **Projects**: `project:home`, `project:work.coding`
+- **Tags**: `+urgent`, `+shopping`, `-someday`
+- **Due dates**: `due:tomorrow`, `due:2024-12-31`, `due:eom`
+- **Scheduled dates**: `scheduled:monday`, `scheduled:2024-12-25`
+- **Priority**: `priority:H`, `priority:M`, `priority:L`
+- **Any Taskwarrior attribute**: `wait:1week`, `until:eoy`, `depends:UUID`, etc.
+
+**Example:**
+
+Before sync:
+```markdown
+- [ ] Buy groceries project:home +shopping due:friday
+```
+
+After `:TWSyncTasks`:
+```markdown
+- [ ] Buy groceries $id{uuid-here}
+```
+
+The task in Taskwarrior will have:
+- Description: `Buy groceries`
+- Project: `home`
+- Tags: `shopping`
+- Due: `friday`
+
+This allows you to quickly capture tasks with context inline, while keeping your markdown clean and readable.
 
 ## Maybe Feature
 
@@ -234,6 +267,7 @@ If you are using `markdown.nvim`, you can set the following configuration:
     - If they are all deleted tasks, it returns `deleted`.
     - If none of the above conditions are met, it returns "unknown" (or any other default value).
 - `:TWSyncTasks`: traverse the current buffer and sync all tasks
+  - Parses inline Taskwarrior attributes (e.g., `project:home`, `+tag`, `due:tomorrow`) and applies them to tasks
   - There are a few scenarios, that may happen:
     - If the task is not in Taskwarrior, and doesn't have UUID, it will add the task to Taskwarrior and add the UUID to the buffer
     - If the task is not in Taskwarrior, but have UUID in the follow format `$id{uuid}` then it will add the task to TaskWarrior and update the UUID

--- a/lua/m_taskwarrior_d/init.lua
+++ b/lua/m_taskwarrior_d/init.lua
@@ -303,11 +303,6 @@ function M.run_task_bulk(args)
       end,
     })
   else
-    -- local _, result = M.task.execute_taskwarrior_command(command, true)
-    -- if #result == 0 then
-    --   print("No task found")
-    --   return
-    -- end
     local task_commands_not_to_display = { "add", "mod", "del", "purge" }
     local good_command = false
     local command = table.concat(args, " ")

--- a/lua/m_taskwarrior_d/utils.lua
+++ b/lua/m_taskwarrior_d/utils.lua
@@ -639,7 +639,10 @@ function M.apply_context_data(line, line_number)
     end
   end
   for _, task_uuid in ipairs(tasks) do
-    require("m_taskwarrior_d.task").execute_taskwarrior_command("task " .. task_uuid .. " mod " .. query)
+    local task = require("m_taskwarrior_d.task")
+    local args = { "task", task_uuid, "mod" }
+    task.append_tokens(args, query)
+    task.execute_task_args(args)
   end
 end
 

--- a/lua/m_taskwarrior_d/utils.lua
+++ b/lua/m_taskwarrior_d/utils.lua
@@ -345,17 +345,7 @@ function M.add_or_sync_task(line, replace_desc)
   local _, _, uuid = string.match(line, M.id_part_pattern.lua)
   if uuid == nil then
     uuid = require("m_taskwarrior_d.task").add_task(desc)
-    local new_task = require("m_taskwarrior_d.task").get_task_by(uuid, "task")
-    local clean_desc = new_task and new_task.description or M.trim(desc)
-    local spaces = count_leading_spaces(line)
-    result = string.rep(" ", spaces or 0)
-      .. list_sb
-      .. " "
-      .. M.checkbox_prefix
-      .. status
-      .. M.checkbox_suffix
-      .. " "
-      .. clean_desc
+    result = line:gsub("%s+$", "")
       .. (M.comment_prefix ~= "" and " " .. M.comment_prefix or M.comment_prefix)
       .. " $id{"
       .. uuid
@@ -366,17 +356,7 @@ function M.add_or_sync_task(line, replace_desc)
     if require("m_taskwarrior_d.task").get_task_by(uuid) == nil then
       line = string.gsub(line, M.id_part_pattern.lua, "")
       uuid = require("m_taskwarrior_d.task").add_task(desc)
-      local new_task = require("m_taskwarrior_d.task").get_task_by(uuid, "task")
-      local clean_desc = new_task and new_task.description or M.trim(desc)
-      local spaces = count_leading_spaces(line)
-      result = string.rep(" ", spaces or 0)
-        .. list_sb
-        .. " "
-        .. M.checkbox_prefix
-        .. status
-        .. M.checkbox_suffix
-        .. " "
-        .. clean_desc
+      result = line:gsub("%s+$", "")
         .. (M.comment_prefix ~= "" and " " .. M.comment_prefix or M.comment_prefix)
         .. " $id{"
         .. uuid
@@ -400,8 +380,6 @@ function M.add_or_sync_task(line, replace_desc)
         local spaces = count_leading_spaces(line)
         if replace_desc then
           require("m_taskwarrior_d.task").modify_task(uuid, desc)
-          local updated_task = require("m_taskwarrior_d.task").get_task_by(uuid, "task")
-          local clean_desc = updated_task and updated_task.description or M.trim(desc)
           result = string.rep(" ", spaces or 0)
             .. list_sb
             .. " "
@@ -409,10 +387,10 @@ function M.add_or_sync_task(line, replace_desc)
             .. new_task_status_sym
             .. M.checkbox_suffix
             .. " "
-            .. clean_desc
+            .. M.trim(desc)
             .. (M.comment_prefix ~= "" and " " .. M.comment_prefix or M.comment_prefix)
             .. " $id{"
-            .. (updated_task and updated_task.uuid or new_task.uuid)
+            .. new_task.uuid
             .. "}"
             .. (M.comment_suffix ~= "" and " " .. M.comment_suffix or M.comment_suffix)
         else

--- a/lua/m_taskwarrior_d/utils.lua
+++ b/lua/m_taskwarrior_d/utils.lua
@@ -345,7 +345,17 @@ function M.add_or_sync_task(line, replace_desc)
   local _, _, uuid = string.match(line, M.id_part_pattern.lua)
   if uuid == nil then
     uuid = require("m_taskwarrior_d.task").add_task(desc)
-    result = line:gsub("%s+$", "")
+    local new_task = require("m_taskwarrior_d.task").get_task_by(uuid, "task")
+    local clean_desc = new_task and new_task.description or M.trim(desc)
+    local spaces = count_leading_spaces(line)
+    result = string.rep(" ", spaces or 0)
+      .. list_sb
+      .. " "
+      .. M.checkbox_prefix
+      .. status
+      .. M.checkbox_suffix
+      .. " "
+      .. clean_desc
       .. (M.comment_prefix ~= "" and " " .. M.comment_prefix or M.comment_prefix)
       .. " $id{"
       .. uuid
@@ -356,7 +366,17 @@ function M.add_or_sync_task(line, replace_desc)
     if require("m_taskwarrior_d.task").get_task_by(uuid) == nil then
       line = string.gsub(line, M.id_part_pattern.lua, "")
       uuid = require("m_taskwarrior_d.task").add_task(desc)
-      result = line:gsub("%s+$", "")
+      local new_task = require("m_taskwarrior_d.task").get_task_by(uuid, "task")
+      local clean_desc = new_task and new_task.description or M.trim(desc)
+      local spaces = count_leading_spaces(line)
+      result = string.rep(" ", spaces or 0)
+        .. list_sb
+        .. " "
+        .. M.checkbox_prefix
+        .. status
+        .. M.checkbox_suffix
+        .. " "
+        .. clean_desc
         .. (M.comment_prefix ~= "" and " " .. M.comment_prefix or M.comment_prefix)
         .. " $id{"
         .. uuid
@@ -380,6 +400,8 @@ function M.add_or_sync_task(line, replace_desc)
         local spaces = count_leading_spaces(line)
         if replace_desc then
           require("m_taskwarrior_d.task").modify_task(uuid, desc)
+          local updated_task = require("m_taskwarrior_d.task").get_task_by(uuid, "task")
+          local clean_desc = updated_task and updated_task.description or M.trim(desc)
           result = string.rep(" ", spaces or 0)
             .. list_sb
             .. " "
@@ -387,10 +409,10 @@ function M.add_or_sync_task(line, replace_desc)
             .. new_task_status_sym
             .. M.checkbox_suffix
             .. " "
-            .. M.trim(desc)
+            .. clean_desc
             .. (M.comment_prefix ~= "" and " " .. M.comment_prefix or M.comment_prefix)
             .. " $id{"
-            .. new_task.uuid
+            .. (updated_task and updated_task.uuid or new_task.uuid)
             .. "}"
             .. (M.comment_suffix ~= "" and " " .. M.comment_suffix or M.comment_suffix)
         else


### PR DESCRIPTION
# Summary
Enable inline parsing of Taskwarrior attributes in markdown task text. Users can now write tasks with attributes like project:home, +tags, and due:tomorrow directly in the markdown, and the plugin will automatically parse and apply them to Taskwarrior while keeping the markdown clean.

# Changes
## Implementation
- task.lua: Added shell_escape_task_args() function that intelligently tokenizes task input:
  - Passes Taskwarrior attributes (project:X, +tag, due:X, etc.) unquoted so Taskwarrior's native parser handles them
  - Single-quotes plain description words for shell safety
  - Both add_task() and modify_task() now use this function instead of wrapping everything in double quotes
- utils.lua: Updated add_or_sync_task() to fetch task descriptions back from Taskwarrior:
  - After adding a new task, retrieves the clean description (with attributes stripped)
  - Updates markdown lines to display only the description text, not the raw attribute syntax
  - Ensures consistency across all task creation/update flows
## Documentation
- README.md: Added comprehensive documentation:
  - New "Inline Taskwarrior Attributes" section with supported syntax examples
  - Before/after example showing how - [ ] Buy groceries project:home +shopping due:friday becomes - [ ] Buy groceries $id{...}
  - Updated :TWSyncTasks command documentation to clarify attribute parsing behavior
# Example Usage
Before sync:
- [ ] Buy groceries project:home +shopping due:friday
- [ ] Write report priority:H project:work due:eom
After :TWSyncTasks:
- [ ] Buy groceries $id{uuid-123}
- [ ] Write report $id{uuid-456}
Tasks are created in Taskwarrior with the attributes applied (project, tags, due dates, etc.), but the markdown remains clean and readable.

# Benefits
1. Faster task capture - Add context inline without separate attribute commands
2. Clean markdown - Display only task descriptions, let the UUID conceal mechanism hide IDs
3. Full TW compatibility - Supports any Taskwarrior attribute syntax natively
4. Safe shell handling - Proper escaping prevents injection while preserving attribute parsing